### PR TITLE
Fix server command in direct messages

### DIFF
--- a/obsidion/cogs/info/info.py
+++ b/obsidion/cogs/info/info.py
@@ -154,7 +154,7 @@ class Info(commands.Cog):
     ):
         """Minecraft server info."""
         await ctx.channel.trigger_typing()
-        if address is None:
+        if address is None and ctx.guild is not None:
             address = await self.bot._guild_cache.get_server(ctx.guild)
         if address is None:
             await ctx.send(_("Please provide a server"))

--- a/obsidion/cogs/info/info.py
+++ b/obsidion/cogs/info/info.py
@@ -140,6 +140,7 @@ class Info(commands.Cog):
         """Returns the server icon."""
         if ":" in ip:  # deal with them providing port in string instead of separate
             address, _port = ip.split(":")
+            port = int(_port)
             return (address, port)
         if port is not None:
             return (ip, port)

--- a/obsidion/cogs/info/info.py
+++ b/obsidion/cogs/info/info.py
@@ -169,7 +169,7 @@ class Info(commands.Cog):
         if await self.bot.redis.exists(key):
             data = json.loads(await self.bot.redis.get(key))
         else:
-            params = (
+            params: Dict[str, Union[str, int]] = (
                 {"server": address}
                 if port is None
                 else {"server": address, "port": port}

--- a/obsidion/cogs/info/info.py
+++ b/obsidion/cogs/info/info.py
@@ -140,7 +140,6 @@ class Info(commands.Cog):
         """Returns the server icon."""
         if ":" in ip:  # deal with them providing port in string instead of separate
             address, _port = ip.split(":")
-            port = int(_port)
             return (address, port)
         if port is not None:
             return (ip, port)
@@ -159,6 +158,9 @@ class Info(commands.Cog):
             address = await self.bot._guild_cache.get_server(ctx.guild)
         if address is None:
             await ctx.send(_("Please provide a server"))
+            return
+        if len(address.split(":")) > 2:
+            await ctx.send(_("Please provide a valid address"))
             return
         server_ip, _port = self.get_server(address, port)
         port = _port if _port else port
@@ -247,6 +249,10 @@ class Info(commands.Cog):
     ) -> None:
         """Get information from a Minecraft Bedrock server."""
         await ctx.channel.trigger_typing()
+        if len(address.split(":")) > 2:
+            await ctx.send(_("Please provide a valid address"))
+            return
+        address, port = self.get_server(address, port)
         params: Dict[str, Union[str, int]] = (
             {"server": address} if port is None else {"server": address, "port": port}
         )


### PR DESCRIPTION
Fix server command in direct messages when guild is none.

Closes #176 